### PR TITLE
Add a t4 file that can turn CoffeeScript into JavaScript while editing

### DIFF
--- a/create_nuget_package.ps1
+++ b/create_nuget_package.ps1
@@ -2,10 +2,12 @@
 
 # copy files from a succesfull Visual Studio release build
 new-item -itemtype directory  NuGet\content
+new-item -itemtype directory  NuGet\content\Scripts
 new-item -itemtype directory  NuGet\lib
 new-item -itemtype directory  NuGet\tool
 
 Copy-Item src\web.config.transform  NuGet\content
+Copy-Item src\Scripts\MakeCoffee.tt  NuGet\content\Scripts
 
 Copy-Item src\CoffeeScriptHttpHandler\bin\Release\CoffeeScriptHttpHandler.dll  NuGet\lib
 Copy-Item src\CoffeeScriptHttpHandler\bin\Release\CoffeeSharp.dll              NuGet\lib

--- a/create_nuget_package.ps1
+++ b/create_nuget_package.ps1
@@ -7,7 +7,7 @@ new-item -itemtype directory  NuGet\lib
 new-item -itemtype directory  NuGet\tool
 
 Copy-Item src\web.config.transform  NuGet\content
-Copy-Item src\Scripts\MakeCoffee.tt  NuGet\content\Scripts
+Copy-Item src\Scripts\MakeCoffee.t4  NuGet\content\Scripts
 
 Copy-Item src\CoffeeScriptHttpHandler\bin\Release\CoffeeScriptHttpHandler.dll  NuGet\lib
 Copy-Item src\CoffeeScriptHttpHandler\bin\Release\CoffeeSharp.dll              NuGet\lib

--- a/create_nuget_package.ps1
+++ b/create_nuget_package.ps1
@@ -4,7 +4,7 @@
 new-item -itemtype directory  NuGet\content
 new-item -itemtype directory  NuGet\content\Scripts
 new-item -itemtype directory  NuGet\lib
-new-item -itemtype directory  NuGet\tool
+new-item -itemtype directory  NuGet\tools
 
 Copy-Item src\web.config.transform  NuGet\content
 Copy-Item src\Scripts\MakeCoffee.t4  NuGet\content\Scripts
@@ -13,9 +13,10 @@ Copy-Item src\CoffeeScriptHttpHandler\bin\Release\CoffeeScriptHttpHandler.dll  N
 Copy-Item src\CoffeeScriptHttpHandler\bin\Release\CoffeeSharp.dll              NuGet\lib
 Copy-Item src\CoffeeScriptHttpHandler\bin\Release\Jurassic.dll                 NuGet\lib
 
-Copy-Item src\Coffee\bin\Release\Coffee.exe       NuGet\tool
-Copy-Item src\Coffee\bin\Release\CoffeeSharp.dll  NuGet\tool
-Copy-Item src\Coffee\bin\Release\Jurassic.dll     NuGet\tool
+Copy-Item src\Coffee\bin\Release\Coffee.exe       NuGet\tools
+Copy-Item src\Coffee\bin\Release\CoffeeSharp.dll  NuGet\tools
+Copy-Item src\Coffee\bin\Release\Jurassic.dll     NuGet\tools
+Copy-Item tools\install.ps1                       NuGet\tools
 
 Copy-Item src\CoffeeSharp.nuspec  NuGet
 

--- a/src/CoffeeSharp/CoffeeSharp.csproj
+++ b/src/CoffeeSharp/CoffeeSharp.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Jurassic">
-      <HintPath>..\Lib\Jurassic.dll</HintPath>
+      <HintPath>..\..\lib\Jurassic.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Scripts/MakeCoffee.t4
+++ b/src/Scripts/MakeCoffee.t4
@@ -1,6 +1,6 @@
 ﻿<#@ import namespace="System" #>
 <#@ import namespace="System.IO" #>
-<#@ assembly name="$(SolutionDir)/packages/CoffeeSharp.0.2/lib/CoffeeSharp.dll" #>
+<#@ assembly name="$(SolutionDir)/packages/CoffeeSharp.$packageversion$/lib/CoffeeSharp.dll" #>
 <#@ import namespace="CoffeeSharp" #>
 <#= MakeCoffee() #>
 

--- a/src/Scripts/MakeCoffee.t4
+++ b/src/Scripts/MakeCoffee.t4
@@ -11,13 +11,13 @@
 	//	    the converted js file should pop-up (remove the tag spaces):
 	//			< #@ template language="C#" hostspecific="True" # >
 	//			< #@ output extension=".coffee.js" # >
-	//			< #@ include file="MakeCoffee.tt" # >
+	//			< #@ include file="MakeCoffee.t4" # >
 	//		This way, every time the coffee file is saved, the generated js file will be updated automatically
 	//	2.  Without T4Toolbox, add a T4 template to your scripts folder and put the following T4 code in it 
 	//      (remove the tag spaces):
 	//			< #@ template language="C#" hostspecific="True" # >
 	//			< #@ output extension=".coffee.js" # >
-	//			< #@ include file="MakeCoffee.tt"  # >
+	//			< #@ include file="MakeCoffee.t4"  # >
 	//			< #= MakeCoffee("<your.coffee>")   # >
 	//		This will work but the resulting js code will not be generated each time the coffee file is changed, 
 	//		but each time perform "Run Custom Tool" from the T4 file's context menu.

--- a/src/Scripts/MakeCoffee.tt
+++ b/src/Scripts/MakeCoffee.tt
@@ -8,18 +8,17 @@
 	//  To automatically convert *.coffee files there are two possibilities
 	//	1.  Using T4Toolbox, set the "Custom Tool" of the coffee file to 'T4ScriptFileGenerator', this will
 	//	    cause a tt file to appear below the coffee file.  Put the following templating code in there and
-	//	    the converted js file should pop-up:
-	/*			<#@ template language="C#" hostspecific="True" #>
-				<#@ output extension=".coffee.js" #>
-				<#@ include file="MakeCoffee.tt" #>
-	*/				
+	//	    the converted js file should pop-up (remove the tag spaces):
+	//			< #@ template language="C#" hostspecific="True" # >
+	//			< #@ output extension=".coffee.js" # >
+	//			< #@ include file="MakeCoffee.tt" # >
 	//		This way, every time the coffee file is saved, the generated js file will be updated automatically
-	//	2.  Without T4Toolbox, add a T4 template to your scripts folder and put the following T4 code in it
-	/*			<#@ template language="C#" hostspecific="True" #>
-				<#@ output extension=".coffee.js" #>
-				<#@ include file="MakeCoffee.tt" #>
-				<#= MakeCoffee("<your.coffee>") #>
-	*/
+	//	2.  Without T4Toolbox, add a T4 template to your scripts folder and put the following T4 code in it 
+	//      (remove the tag spaces):
+	//			< #@ template language="C#" hostspecific="True" # >
+	//			< #@ output extension=".coffee.js" # >
+	//			< #@ include file="MakeCoffee.tt"  # >
+	//			< #= MakeCoffee("<your.coffee>")   # >
 	//		This will work but the resulting js code will not be generated each time the coffee file is changed, 
 	//		but each time perform "Run Custom Tool" from the T4 file's context menu.
 #>	

--- a/src/Scripts/MakeCoffee.tt
+++ b/src/Scripts/MakeCoffee.tt
@@ -1,0 +1,47 @@
+﻿<#@ import namespace="System" #>
+<#@ import namespace="System.IO" #>
+<#@ assembly name="$(SolutionDir)/packages/CoffeeSharp.0.2/lib/CoffeeSharp.dll" #>
+<#@ import namespace="CoffeeSharp" #>
+<#= MakeCoffee() #>
+<#+
+  	public class CoffeeMachine
+	{
+		private static CoffeeScriptEngine Engine = new CoffeeSharp.CoffeeScriptEngine();
+		
+		public string Input { get; private set;}
+		
+		public CoffeeMachine(string inputFile)
+		{
+			Input = inputFile;
+		}
+		
+		public string Compile()
+		{
+			using(var reader = new StreamReader(Input))
+			{
+				string code = reader.ReadToEnd();
+				return Engine.Compile(code);
+			}
+		}
+	}
+	
+	string MakeCoffee(string name)
+	{
+		var fullPath = Host.ResolvePath(name);
+		var machine = new CoffeeMachine(fullPath);
+		return machine.Compile();
+	}
+	
+	string MakeCoffee()
+	{
+		var templatePath = this.Host.TemplateFile;		
+		var templateFolder = Path.GetDirectoryName(templatePath);
+		var coffeeScriptFile = string.Format("{0}.coffee", Path.GetFileNameWithoutExtension(this.Host.TemplateFile));		
+		var coffeeScriptPath = Path.Combine(templateFolder, coffeeScriptFile);
+		
+		if (!File.Exists(coffeeScriptPath))
+			return string.Empty;
+		
+		return MakeCoffee(coffeeScriptFile);
+	}
+#>

--- a/src/Scripts/MakeCoffee.tt
+++ b/src/Scripts/MakeCoffee.tt
@@ -3,6 +3,27 @@
 <#@ assembly name="$(SolutionDir)/packages/CoffeeSharp.0.2/lib/CoffeeSharp.dll" #>
 <#@ import namespace="CoffeeSharp" #>
 <#= MakeCoffee() #>
+
+<#
+	//  To automatically convert *.coffee files there are two possibilities
+	//	1.  Using T4Toolbox, set the "Custom Tool" of the coffee file to 'T4ScriptFileGenerator', this will
+	//	    cause a tt file to appear below the coffee file.  Put the following templating code in there and
+	//	    the converted js file should pop-up:
+	/*			<#@ template language="C#" hostspecific="True" #>
+				<#@ output extension=".coffee.js" #>
+				<#@ include file="MakeCoffee.tt" #>
+	*/				
+	//		This way, every time the coffee file is saved, the generated js file will be updated automatically
+	//	2.  Without T4Toolbox, add a T4 template to your scripts folder and put the following T4 code in it
+	/*			<#@ template language="C#" hostspecific="True" #>
+				<#@ output extension=".coffee.js" #>
+				<#@ include file="MakeCoffee.tt" #>
+				<#= MakeCoffee("<your.coffee>") #>
+	*/
+	//		This will work but the resulting js code will not be generated each time the coffee file is changed, 
+	//		but each time perform "Run Custom Tool" from the T4 file's context menu.
+#>	
+	
 <#+
   	public class CoffeeMachine
 	{

--- a/tools/Install.ps1
+++ b/tools/Install.ps1
@@ -1,0 +1,6 @@
+param($installPath, $toolsPath, $package, $project)
+
+Write-Host "Replacing project version in MakeCoffee.t4 to" $package.Version
+$coffee_template = ($project.ProjectItems.Item("Scripts").ProjectItems | Where-Object { $_.Name -eq "MakeCoffee.t4" }).FileNames(1)
+
+((Get-Content $coffee_template) | ForEach-Object { $_ -replace "[$]packageversion[$]", $package.Version }) | Set-Content $coffee_template


### PR DESCRIPTION
Hi,

I added a T4 script that is deployed through the Nuget package.  It is added to the Scripts folder and can use the CoffeeScriptEngine to transform a  coffee file into javascript while editing the CoffeeScript file.  By doing so, it is easy to reference the JavaScript from your html, but at the same time you can write CoffeeScript.

Kr,
Thomas
